### PR TITLE
Fixes dead link to real DFIR playbooks in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,6 +157,6 @@ outputs: []
 ------
 
 This is of course a sample (and simple example) just to show an overview of the scheme.
-For real DFIR playbooks look at the [Demisto content repo](https://github.com/demisto/content/tree/master/Playbooks).
+For real DFIR playbooks look at the [Demisto content repo](https://github.com/demisto/content/tree/master/TestPlaybooks).
 
 Feel free to contribute by providing feedback, creating new DFIR playbooks, or using the spec in your security product, contact using issues of this GitHub repo.


### PR DESCRIPTION
The original link lead to 404 - page not found as that directory no longer exists in the master branch. I assume the link should lead to /TestPlaybooks, please confirm.